### PR TITLE
[POPLAR] Integrate the Camera Augmented Sensing Helper and its ToF calibration

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -35,4 +35,6 @@ BOARD_VENDORIMAGE_PARTITION_SIZE := 1610612736
 BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE := ext4
 BOARD_ROOT_EXTRA_SYMLINKS := /vendor/lib/dsp:/dsp
 
+TARGET_USES_CASH_EXTENSION := true
+
 #TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"

--- a/device.mk
+++ b/device.mk
@@ -52,6 +52,10 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/acdbdata/Headset_cal.acdb:$(TARGET_COPY_OUT_VENDOR)/etc/acdbdata/Headset_cal.acdb \
     $(DEVICE_PATH)/vendor/etc/acdbdata/Speaker_cal.acdb:$(TARGET_COPY_OUT_VENDOR)/etc/acdbdata/Speaker_cal.acdb
 
+# Focus calibration
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/etc/tof_focus_calibration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/tof_focus_calibration.xml
+
 # NFC Configuration
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/libnfc-brcm.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-brcm.conf \
@@ -83,6 +87,12 @@ PRODUCT_PACKAGES += \
 # SAR
 PRODUCT_PACKAGES += \
     TransPowerSensors
+
+# Camera Augmented Sensing Helper
+PRODUCT_PACKAGES += \
+   libpolyreg \
+   cashsvr \
+   libcashctl
 
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi

--- a/rootdir/vendor/etc/tof_focus_calibration.xml
+++ b/rootdir/vendor/etc/tof_focus_calibration.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<tof_focus_calibration>
+    <tof_focus>
+        <focus millimeters="1028 860 755 640 541 461 389 297 150 118 106 97 76"
+               focus_step="1823103 2059338 2068330 2211037 2377131 2466841 2874259
+                           3524959 5287231 5905002 6224134 8626117 10000000"/>
+        <polyreg_tuning degree="9" extra="0"/>
+    </tof_focus>
+</tof_focus_calibration>


### PR DESCRIPTION
Add libcashctl, cashsvr, libpolyreg to the build, declare
TARGET_USES_CASH_EXTENSION to build the code in the camera HAL
and copy the tof_focus_calibration XML.