### PR TITLE
BoardConfig: Add a default TARGET_BOOTLOADER_BOARD_NAME

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -20,7 +20,8 @@ TARGET_BOOTLOADER_BOARD_NAME := G8341
 else ifneq (,$(filter %g8342,$(TARGET_PRODUCT)))
 TARGET_BOOTLOADER_BOARD_NAME := G8342
 else
-$(error Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)")
+TARGET_BOOTLOADER_BOARD_NAME := G8341
+$(warning Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)", using default value: "$(TARGET_BOOTLOADER_BOARD_NAME)")
 endif
 
 # Platform


### PR DESCRIPTION
There is no need to break the build when a TARGET_BOOTLOADER_BOARD_NAME can not be derived from TARGET_PRODUCT.
Simply set a valid default value, and warn the user about the issue.
This is useful to guarantee compatibility with projects based on Sony's Open Devices that change TARGET_PRODUCT to fit their needs.