### PR TITLE
Remove unnecessary NFC flags and packages

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -28,7 +28,6 @@ endif
 PRODUCT_PLATFORM := yoshino
 
 # NFC
-NXP_CHIP_TYPE := PN553
 NXP_CHIP_FW_TYPE := PN553
 
 BOARD_KERNEL_CMDLINE += androidboot.hardware=poplar

--- a/device.mk
+++ b/device.mk
@@ -75,10 +75,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     power.poplar
 
-# NFC config
-PRODUCT_PACKAGES += \
-    nfc_nci.poplar
-
 # Telephony Packages (AOSP)
 PRODUCT_PACKAGES += \
     InCallUI \


### PR DESCRIPTION
* These packages and flags no longer exist
  in AOSP 9 codebase.