### PR TITLE
[POPLAR] device: Move CASH to device-sony-yoshino

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -52,6 +52,4 @@ BOARD_VENDORIMAGE_EXTFS_INODE_COUNT := 4096
 
 BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 
-TARGET_USES_CASH_EXTENSION := true
-
 #TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"

--- a/device.mk
+++ b/device.mk
@@ -88,12 +88,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     TransPowerSensors
 
-# Camera Augmented Sensing Helper
-PRODUCT_PACKAGES += \
-   libpolyreg \
-   cashsvr \
-   libcashctl
-
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi


### PR DESCRIPTION
All the Yoshino devices are calibrated and all support CASH:
it makes no sense to keep it per-device.